### PR TITLE
Fix: Schedule User Deletions with WP Cronjob

### DIFF
--- a/um-cron-delete/um-cron-delete.php
+++ b/um-cron-delete/um-cron-delete.php
@@ -16,6 +16,7 @@ add_action( 'um_cron_delete_users_cron', 'um_delete_users_awaiting_email' );
 function um_delete_users_awaiting_email() {
 
 	$after_x     = apply_filters( 'um_cron_delete_users_after', '5 days ago midnight' );
+	$before_x    = apply_filters( 'um_cron_delete_users_before', '1 day ago' );
 	$user_status = apply_filters( 'um_cron_delete_users_status', 'awaiting_email_confirmation' );
 
 	$args = array(
@@ -24,6 +25,7 @@ function um_delete_users_awaiting_email() {
 		'date_query' => array(
 			array(
 				'after'     => $after_x,
+				'before'    => $before_x,
 				'inclusive' => true,
 			),
 		),

--- a/um-cron-delete/um-cron-delete.php
+++ b/um-cron-delete/um-cron-delete.php
@@ -41,8 +41,8 @@ function um_delete_users_awaiting_email() {
 
 	$users = get_users( $args );
 
-	foreach ( $users as $user ) {
-		um_fetch_user( $user->ID );
+	foreach ( $users as $user_id ) {
+		um_fetch_user( $user_id );
 		UM()->user()->delete();
 	}
 }

--- a/um-cron-delete/um-cron-delete.php
+++ b/um-cron-delete/um-cron-delete.php
@@ -3,45 +3,49 @@
 Plugin Name: Ultimate Member - Schedule User Deletions with WP Cronjob
 Plugin URI: http://ultimatemember.com/
 Description: Deletes users by status after X number of days/months/years
-Version: 1.0.0
+Version: 1.0.1
 Author: UM Devs
 Author URI: https://ultimatemember.com
 */
 
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 add_action( 'um_cron_delete_users_cron', 'um_delete_users_awaiting_email' );
-function um_delete_users_awaiting_email(){
+function um_delete_users_awaiting_email() {
 
-    $after_x = apply_filters("um_cron_delete_users_after", "5 days ago midnight");
-    $user_status = apply_filters("um_cron_delete_users_status", "awaiting_email_confirmation");
+	$after_x     = apply_filters( 'um_cron_delete_users_after', '5 days ago midnight' );
+	$user_status = apply_filters( 'um_cron_delete_users_status', 'awaiting_email_confirmation' );
 
-    $args = array(
-      'fields'     => 'ID',
-      'number'     => -1,
-      'date_query' => array(
-          array( 'after'  => $after_x, 'inclusive' => true ),
-      ),
-      'meta_query' => array(
-            "relation" => "AND",
-            array(
-                  "key" => "status",
-                  "value" => $user_status,
-                  "compare" => "=" 
-            )
-      )
-  );
-   
-  $users = get_users( $args );
+	$args = array(
+		'fields'     => 'ids',
+		'number'     => -1,
+		'date_query' => array(
+			array(
+				'after'     => $after_x,
+				'inclusive' => true,
+			),
+		),
+		'meta_query' => array(
+			'relation' => 'AND',
+			array(
+				'key'     => 'account_status',
+				'value'   => $user_status,
+				'compare' => '=',
+			),
+		),
+	);
 
-  foreach( $users as $user ){ 
-      um_fetch_user( $user->ID );
-      UM()->user()->delete();
-  }
+	$users = get_users( $args );
 
+	foreach ( $users as $user ) {
+		um_fetch_user( $user->ID );
+		UM()->user()->delete();
+	}
 }
 
 if ( ! wp_next_scheduled( 'um_cron_delete_users_cron' ) ) {
-    $recurrence = apply_filters("um_cron_delete_users_recurrence", "daily");
-    wp_schedule_event( time(), 'daily', 'um_cron_delete_users_cron' );
+	$recurrence = apply_filters( 'um_cron_delete_users_recurrence', 'daily' );
+	wp_schedule_event( time(), $recurrence, 'um_cron_delete_users_cron' );
 }


### PR DESCRIPTION
Fixed:
- meta_query key to get users by their account status.
- wp_schedule_event function $recurrence parameter.
- coding standards (WPCS).

Added:
- the 'before' key to the date_query parameter.
- the um_cron_delete_users_before hook.