### PR TITLE
Blocked removing the vcard.vcf file on profile update

### DIFF
--- a/src/um-vcard/src/Core.php
+++ b/src/um-vcard/src/Core.php
@@ -60,7 +60,7 @@ class Core {
 		// Remove unused field options.
 		add_filter(
 			'um_core_fields_hook',
-			function( $fields ) {
+			function ( $fields ) {
 				if ( isset( $_REQUEST['arg3'] ) && 'vcard' === $_REQUEST['arg3'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 					$fields['file']['col1'] = array( '_title', '_metakey', '_help', '_visibility' );
 					$fields['file']['col2'] = array( '_label', '_public', '_roles', '_icon' );
@@ -69,7 +69,6 @@ class Core {
 				return $fields;
 			}
 		);
-
 	}
 
 
@@ -85,10 +84,10 @@ class Core {
 	 * @return boolean
 	 */
 	public function block_removing( $can_unlink, $user_id, $str ) {
-		if ( 'vcard.vcf' === $str  ) {
+		if ( 'vcard.vcf' === $str ) {
 			$can_unlink = false;
 		}
-		if ( 0 === strpos( $str, 'vcard-120x120.' )  ) {
+		if ( 0 === strpos( $str, 'vcard-120x120.' ) ) {
 			$can_unlink = false;
 		}
 		return $can_unlink;
@@ -236,7 +235,6 @@ class Core {
 		}
 
 		update_user_meta( $user_id, 'vcard', 'vcard.vcf' );
-
 	}
 
 	/**
@@ -272,6 +270,4 @@ class Core {
 		$big_type = strtoupper( str_replace( 'image/', '', $type ) );
 		return 'data:' . $type . ';ENCODING=b;TYPE=' . $big_type . ':' . base64_encode( $image ); //phpcs:ignore
 	}
-
-
 }

--- a/src/um-vcard/src/Core.php
+++ b/src/um-vcard/src/Core.php
@@ -51,6 +51,9 @@ class Core {
 		// Don't display the field in Edit View.
 		add_filter( 'um_vcard_form_edit_field', '__return_empty_string' );
 
+		// Don't remove the vcard.vcf from the members' folder.
+		add_filter( 'um_can_remove_uploaded_file', array( $this, 'block_removing' ), 10, 3 );
+
 		add_action( 'um_after_user_updated', array( $this, 'generate' ) );
 		add_action( 'um_registration_complete', array( $this, 'generate' ) );
 
@@ -68,6 +71,29 @@ class Core {
 		);
 
 	}
+
+
+	/**
+	 * Don't remove the vcard.vcf file from the members' folder.
+	 *
+	 * @see \um\core\Uploader::remove_unused_uploads()
+	 *
+	 * @param boolean $can_unlink Can unlink or not.
+	 * @param int     $user_id    User ID.
+	 * @param string  $str        File name.
+	 *
+	 * @return boolean
+	 */
+	public function block_removing( $can_unlink, $user_id, $str ) {
+		if ( 'vcard.vcf' === $str  ) {
+			$can_unlink = false;
+		}
+		if ( 0 === strpos( $str, 'vcard-120x120.' )  ) {
+			$can_unlink = false;
+		}
+		return $can_unlink;
+	}
+
 
 	/**
 	 * Generate VCard on profile update


### PR DESCRIPTION
The core plugin removes unused files from the members' folder on profile update. 

The "_This file has been removed._" notice is displayed instead of the **vcard.vcf** file once the profile is updated.
![example - This file has been removed](https://github.com/ultimatemember/Extended/assets/78854651/94190292-b60e-4b2c-ace3-e26940c873fa)

We have to use the `um_can_remove_uploaded_file` hook to prevent removing a file.
I added a code that blocks removing the **vcard.vcf** file and related image file.

@champsupertramp please review and merge these changes. 
Thank you